### PR TITLE
netdev_group support for Juniper device

### DIFF
--- a/libraries/_junos_api_client.rb
+++ b/libraries/_junos_api_client.rb
@@ -37,7 +37,8 @@ module Netdev
           :l2_ports => ::Junos::Ez::L2ports,
           :ip_ports => ::Junos::Ez::IPports,
           :vlans => ::Junos::Ez::Vlans,
-          :lag_ports => ::Junos::Ez::LAGports
+          :lag_ports => ::Junos::Ez::LAGports,
+          :group => ::Junos::Ez::Group
         }
 
         KNOWN_RESOURCES.each_pair do |resource, provider_module|

--- a/libraries/_junos_api_transport.rb
+++ b/libraries/_junos_api_transport.rb
@@ -77,16 +77,16 @@ module Netdev
       def commit_transaction!(commit_log_comment = nil)
         opts = {}
         opts[:comment] = commit_log_comment if commit_log_comment
-        if @transaction_open
-           # commit the candidate configuration
-           @transport_config.commit!(opts)
-           Chef::Log.info('Committed pending Junos candidate configuration changes')
-           # release the exclusive lock on the configuration
-           @transport_config.unlock!
-           Chef::Log.info('Released exclusive Junos configuration lock')
-           @transaction_open = false
-        else
-           Chef::Log.debug("#{self}: Nothing to commit !! ")
+        # commit the candidate configuration
+	if @transaction_open
+          @transport_config.commit!(opts)
+          Chef::Log.info('Committed pending Junos candidate configuration changes')
+          # release the exclusive lock on the configuration
+          @transport_config.unlock!
+          Chef::Log.info('Released exclusive Junos configuration lock')
+          @transaction_open = false
+	else
+	  Chef::Log.debug("#{self}: Nothing to commit !! ")
         end
       end
 

--- a/libraries/platform_provider_mapping.rb
+++ b/libraries/platform_provider_mapping.rb
@@ -24,6 +24,7 @@ require_relative 'provider_lag_eos'
 require_relative 'provider_lag_junos'
 require_relative 'provider_vlan_eos'
 require_relative 'provider_vlan_junos'
+require_relative 'provider_group_junos'
 
 #########################################################################
 # Chef::Resource::NetdevInterface Providers
@@ -83,4 +84,13 @@ Chef::Platform.set(
   platform: :junos,
   resource: :netdev_vlan,
   provider: Chef::Provider::NetdevVirtualLAN::Junos
+)
+
+#########################################################################
+# Chef::Resource::NetdevGroup Providers
+#########################################################################
+Chef::Platform.set(
+  platform: :junos,
+  resource: :netdev_group,
+  provider: Chef::Provider::NetdevGroup::Junos
 )

--- a/libraries/provider_group_junos.rb
+++ b/libraries/provider_group_junos.rb
@@ -1,0 +1,113 @@
+#
+# Cookbook Name:: netdev
+# Provider:: group
+#
+# Copyright 2014, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/resource'
+require 'chef/provider'
+
+require_relative '_helper'
+require_relative '_junos_api_client'
+require_relative 'resource_group'
+
+class Chef
+  class Provider::NetdevGroup::Junos < Provider
+    include Netdev::Helper
+
+    #
+    # This provider supports why-run mode.
+    #
+    def whyrun_supported?
+      true
+    end
+
+    def load_current_resource 
+      @current_resource = Chef::Resource::NetdevGroup.new(new_resource.name)
+      @current_resource.group_name(new_resource.group_name)
+
+      if (group = junos_client.managed_resource) && group.exists?
+        @current_resource.exists = true
+      else
+        @current_resource.exists = false
+      end
+      
+      @file_path = "/var/tmp/#{new_resource.name}"
+      @new_values = new_resource.state
+      @current_values = current_resource.state
+
+      @template_resource = Chef::Resource::Template.new(@file_path, run_context)
+      @template_resource.source (@new_values[:template_path]) 
+      @template_resource.cookbook (new_resource.cookbook_name)
+      @template_resource.variables (@new_values[:variables])
+      @template_resource.run_action( @action )
+      @is_resource_updated =  @template_resource.updated_by_last_action?
+      @current_resource
+    end
+
+    #
+    # Create the given group.
+    #
+    def action_create
+      unless @is_resource_updated or not @current_resource.exists
+	Chef::Log.info("Configuration file is same. Nothing to commit.")
+        return
+      end
+      @new_values[:path] = @file_path
+      format = (@new_values[:template_path].split('/'))[-1].split('.') 
+      if format[1] != 'erb' 
+        @new_values[:format] = format[1]
+      else
+	@new_values[:format] = 'xml'  
+      end
+
+      @new_values.delete(:template_path)
+      @current_values.delete(:template_path)
+      @new_values.delete(:variables)
+      @current_values.delete(:variables)
+      updated_values = junos_client.updated_changed_properties(@new_values,
+                                                               @current_values)
+      unless updated_values.empty?
+        message  = "create JUNOS group #{new_resource.name} and apply it."
+        converge_by(message) do
+          junos_client.write!
+        end
+      end
+    end
+
+    #
+    # Delete the given group.
+    #
+    def action_delete
+      unless @is_resource_updated
+        Chef::Log.info("Configuration is deleted. Nothing to commit.")
+        return
+      end
+
+      if current_resource.exists?
+        converge_by("delete JUNOS group #{new_resource.name}") do
+          junos_client.delete!
+        end
+      end
+    end
+
+    private
+
+    def junos_client
+      @junos_client ||= Netdev::Junos::ApiClient::Group.new(new_resource.group_name)
+    end
+  end
+end

--- a/libraries/resource_group.rb
+++ b/libraries/resource_group.rb
@@ -1,0 +1,91 @@
+#
+# Cookbook Name:: netdev
+# Resource:: JUNOS apply group
+#
+# Copyright 2014, Chef Software, Inc.
+# Copyright 2015, Juniper Network.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/resource'
+require 'chef/provider'
+
+class Chef
+  class Resource::NetdevGroup < Resource
+    provides      :netdev_group
+    identity_attr :group_name
+    state_attrs   :template_path, :variables  
+
+    attr_accessor :exists
+    alias_method  :exists?, :exists
+
+    def initialize(name, run_context = nil)
+      super
+
+      @resource_name = :netdev_group
+
+      # Set default actions and allowed actions
+      @action = :create
+      @allowed_actions.push(:create, :delete)
+
+      # Set the name attribute and default attributes
+      @group_name      = name
+      
+      @enable          = true       
+      #@variables       = Hash.new
+      # State attributes that are set by the provider
+      @exists          = false
+    end
+
+    #
+    # The name of the JUNOS Group.
+    #
+    # @param [String] arg
+    # @return [String]
+    #
+    def group_name(arg = nil)
+      set_or_return(:group_name, arg, kind_of: String)
+    end
+
+    #
+    # The variables to template.
+    #
+    # @param [HASH] arg
+    # @return [HASH]
+    #
+    def variables(args=nil)
+      set_or_return(
+        :variables,
+        args,
+        :kind_of => [ Hash ]
+      )
+    end
+
+    #
+    # The JUNOS configuration template path.
+    #
+    # @param [String] arg
+    # @return [String]
+    #
+    def template_path(arg=nil)
+      set_or_return(
+        :template_path,
+        arg,
+        :kind_of => String
+      )
+    end
+
+  end
+end
+class Chef::Provider::NetdevGroup; end

--- a/test/fixtures/cookbooks/group/attributes/default.rb
+++ b/test/fixtures/cookbooks/group/attributes/default.rb
@@ -1,0 +1,20 @@
+default[:netdev][:services] = [['ftp'] , ['ssh'], ['netconf', 'ssh']]
+default[:netdev][:bgp] = {
+    'internal' =>  {
+        'type' => 'internal',
+        'neighbor' => [ '10.10.10.10', '10.10.10.11' ],
+        'local-address' => '20.20.20.20',
+        'peer-as' => '100'
+     },
+     'external' => {
+         'type' => 'external',
+         'neighbor' => [ '30.30.10.10', '30.30.10.11' ],
+         'local-address' => '20.20.20.20',
+         'peer-as' => '200'
+     }
+}
+
+default[:netdev][:syslog] = {
+  'messages' => [ { 'facility' => 'any', 'level' => 'critical' }, { 'facility' => 'authorization', 'level' => 'info' } ] ,
+  'interactive-commands' => [ { 'facility' => 'interactive-commands', 'level' => 'error'} ]       
+}

--- a/test/fixtures/cookbooks/group/metadata.rb
+++ b/test/fixtures/cookbooks/group/metadata.rb
@@ -1,0 +1,2 @@
+name    'group'
+depends 'netdev'

--- a/test/fixtures/cookbooks/group/recipes/bgp_create.rb
+++ b/test/fixtures/cookbooks/group/recipes/bgp_create.rb
@@ -1,0 +1,9 @@
+
+netdev_group 'bgp_group' do
+        template_path 'bgp.xml.erb'
+        action :create
+        variables({
+          :bgp => node[:netdev][:bgp]
+        })
+end
+

--- a/test/fixtures/cookbooks/group/recipes/bgp_delete.rb
+++ b/test/fixtures/cookbooks/group/recipes/bgp_delete.rb
@@ -1,0 +1,6 @@
+
+netdev_group 'bgp_group' do
+        template_path 'bgp.xml.erb'
+        action :delete
+end
+

--- a/test/fixtures/cookbooks/group/recipes/service_create.rb
+++ b/test/fixtures/cookbooks/group/recipes/service_create.rb
@@ -1,0 +1,9 @@
+
+netdev_group 'service_group' do
+	template_path 'services.set.erb'
+	action :create
+	variables({
+	  :services => node[:netdev][:services]
+	})
+end
+ 

--- a/test/fixtures/cookbooks/group/recipes/service_delete.rb
+++ b/test/fixtures/cookbooks/group/recipes/service_delete.rb
@@ -1,0 +1,6 @@
+
+netdev_group 'service_group' do
+        template_path 'services.set.erb'
+        action :delete
+end
+

--- a/test/fixtures/cookbooks/group/recipes/syslog_create.rb
+++ b/test/fixtures/cookbooks/group/recipes/syslog_create.rb
@@ -1,0 +1,9 @@
+
+netdev_group 'syslog_group' do
+        template_path 'syslog.text.erb'
+        action :create
+        variables({
+          :syslog_names => node[:netdev][:syslog]
+        })
+end
+

--- a/test/fixtures/cookbooks/group/recipes/syslog_delete.rb
+++ b/test/fixtures/cookbooks/group/recipes/syslog_delete.rb
@@ -1,0 +1,6 @@
+
+netdev_group 'syslog_group' do
+        template_path 'syslog.text.erb'
+        action :delete
+end
+

--- a/test/fixtures/cookbooks/group/templates/junos/bgp.xml.erb
+++ b/test/fixtures/cookbooks/group/templates/junos/bgp.xml.erb
@@ -1,0 +1,18 @@
+<% @bgp.each do | name, hash | %>
+            <protocols>
+                <bgp>
+                    <group>
+                        <name><%=name%></name>
+                        <type><%= hash['type']%></type>
+                        <local-address><%= hash['local-address']%></local-address>
+                        <% hash['neighbor'].each do | neighbor | %>
+                        <neighbor>
+                            <name><%=neighbor%></name>
+                        </neighbor>
+                         <% end %>
+                        <peer-as><%= hash['peer-as']%></peer-as>
+                    </group>
+                </bgp>
+            </protocols>
+<% end %>
+

--- a/test/fixtures/cookbooks/group/templates/junos/services.set.erb
+++ b/test/fixtures/cookbooks/group/templates/junos/services.set.erb
@@ -1,0 +1,3 @@
+<% @services.each do | service | %>
+set system services <%= service[0] %> <%= service[1] %>
+<% end %>

--- a/test/fixtures/cookbooks/group/templates/junos/syslog.text.erb
+++ b/test/fixtures/cookbooks/group/templates/junos/syslog.text.erb
@@ -1,0 +1,11 @@
+system {
+    syslog {
+    <% @syslog_names.each do | name, details | %>
+    	<% details.each do | detail | %>
+		file <%= name %> {
+             		<%= detail['facility'] %> <%= detail['level'] %>
+ 		}
+        <% end %>
+    <% end %> 
+    }
+}


### PR DESCRIPTION
Add 'netdev_group' support to enable generic configuration using ruby ERB templates under JUNOS group hierarchy.
