### PR TITLE
Adds ability for chef-client to work from a container environment for Junos-specific modules

### DIFF
--- a/libraries/_junos_api_transport.rb
+++ b/libraries/_junos_api_transport.rb
@@ -19,6 +19,8 @@ require 'singleton'
 
 require_relative '_junos_api_client'
 
+IS_CONTAINER = system("grep -qa /docker /proc/1/cgroup")
+
 begin
   if IS_CONTAINER
     require 'net/netconf/jnpr'


### PR DESCRIPTION
## Summary
The pull request allows the container to operate from a container environment, it uses Netconf::SSH method to authenticate to the target device.

**_Requirements_**:

A passwordless authentication should be setup b/w target and container.
The user that is configured to perform Puppet operations should be exported as an environment variable. **Command**: `export NETCONF_USER=puppet`